### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/tests/test_email_notification.py
+++ b/tests/test_email_notification.py
@@ -158,8 +158,10 @@ class Test(utc.UnitTest):
                 side_effect=side_effect,
             ):
                 # send message with no inputs, UTIL.NO_ERROR expected
-                body = ("this is a test of the email notification alert for exception "
-                        f"type {str(exception)}.")
+                body = (
+                    "this is a test of the email notification alert for exception "
+                    f"type {str(exception)}."
+                )
                 return_status, return_status_msg = eml.send_email_alert(
                     subject=f"test email alert (mocked {str(exception)} exception)",
                     body=body,

--- a/thermostatsupervisor/email_notification.py
+++ b/thermostatsupervisor/email_notification.py
@@ -156,8 +156,9 @@ def send_email_alert(
         smtplib.SMTPDataError,
         smtplib.SMTPNotSupportedError,
     ) as ex:
-        util.log_msg(f"exception during mail send: {str(ex)}",
-                     mode=util.BOTH_LOG, func_name=1)
+        util.log_msg(
+            f"exception during mail send: {str(ex)}", mode=util.BOTH_LOG, func_name=1
+        )
         server.close()
         return (util.EMAIL_SEND_ERROR, return_status_msg_dict[status])
     server.close()


### PR DESCRIPTION
There appear to be some python formatting errors in f9d794a91c71bc65f8c5e16c01a5117e2593482a. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.