### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/thermostatsupervisor/nest.py
+++ b/thermostatsupervisor/nest.py
@@ -58,14 +58,17 @@ class ThermostatClass(tc.ThermostatCommon):
         self.client_id = os.environ.get("GCLOUD_CLIENT_ID")
         self.client_secret = os.environ.get("GCLOUD_CLIENT_SECRET")
         self.project_id = os.environ.get("DAC_PROJECT_ID")
-        self.credentials_from_env = (self.client_id and self.client_secret
-                                     and self.project_id)
+        self.credentials_from_env = (
+            self.client_id and self.client_secret and self.project_id
+        )
 
         if nest_config.use_credentials_file or not self.credentials_from_env:
             # get credentials from file
             self.google_app_credential_file = ".//credentials.json"
-            print("retreiving Google Nest credientials from "
-                  f"{self.google_app_credential_file}...")
+            print(
+                "retreiving Google Nest credientials from "
+                f"{self.google_app_credential_file}..."
+            )
             with open(self.google_app_credential_file, encoding="utf8") as json_file:
                 data = json.load(json_file)
                 self.client_id = data["web"]["client_id"]

--- a/thermostatsupervisor/nest_config.py
+++ b/thermostatsupervisor/nest_config.py
@@ -19,8 +19,7 @@ env_variables = {
 }
 
 # min required env variables on all runs
-required_env_variables = {
-}
+required_env_variables = {}
 
 # supported thermostat configs
 supported_configs = {


### PR DESCRIPTION
There appear to be some python formatting errors in c3c36b3bd817079da2a306ce26fd0996821d1845. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.