### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/thermostatsupervisor/nest.py
+++ b/thermostatsupervisor/nest.py
@@ -114,8 +114,10 @@ class ThermostatClass(tc.ThermostatCommon):
             self.devices = self.thermostat_obj.get_devices()
         except oauthlib.oauth2.rfc6749.errors.InvalidGrantError as e:
             print(f"ERROR: {e}")
-            print("access token has expired, user must manually reauthorize account "
-                  "and get new access token, then update the access_token.json file.")
+            print(
+                "access token has expired, user must manually reauthorize account "
+                "and get new access token, then update the access_token.json file."
+            )
             raise e
         # TODO is there a chance that meta data changes?
         return self.devices


### PR DESCRIPTION
There appear to be some python formatting errors in 1147e933ae0b8f7b307a82dae22143716bceb684. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.