### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/thermostatsupervisor/environment.py
+++ b/thermostatsupervisor/environment.py
@@ -271,10 +271,7 @@ def dynamic_module_import(name, path=None, pkg=None, verbose=False):
             path = convert_to_absolute_path(path)
 
             # local file import from relative or abs path
-            print(
-                f"WARNING: attempting local import of {name} from "
-                f"path {path}..."
-            )
+            print(f"WARNING: attempting local import of {name} from " f"path {path}...")
             if verbose:
                 print(f"target dir contents={os.listdir(path)}")
                 print(f"adding '{path}' to system path")


### PR DESCRIPTION
There appear to be some python formatting errors in 7dde854f793e97d71abfed523a83894e46898289. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.