### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -228,7 +228,8 @@ class EnvironmentTests(utc.UnitTest):
         self.assertTrue(
             os.path.isabs(absolute_path),
             f"convert_to_absolute_path() returned '{absolute_path}' which is not an "
-            "absolute path",)
+            "absolute path",
+        )
 
         # Test with an empty string
         relative_path = ""
@@ -236,7 +237,8 @@ class EnvironmentTests(utc.UnitTest):
         self.assertTrue(
             os.path.isabs(absolute_path),
             f"convert_to_absolute_path() returned '{absolute_path}' which is not an "
-            "absolute path",)
+            "absolute path",
+        )
 
         # Test with a None input
         with self.assertRaises(TypeError):


### PR DESCRIPTION
There appear to be some python formatting errors in 252ab3bf138ded3b00a0e7c608b34c4fc6f0f764. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.