### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -6,22 +6,21 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'ThermostatSupervisor'
-copyright = '2024, Christopher Krolak'
-author = 'Christopher Krolak'
+project = "ThermostatSupervisor"
+copyright = "2024, Christopher Krolak"
+author = "Christopher Krolak"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = []
 
-templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
-
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
-html_static_path = ['_static']
+html_theme = "alabaster"
+html_static_path = ["_static"]


### PR DESCRIPTION
There appear to be some python formatting errors in 490c6126499151f048bd6b4e197aa6ff73ab7d55. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.