### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/thermostatsupervisor/sht31_flask_server.py
+++ b/thermostatsupervisor/sht31_flask_server.py
@@ -415,10 +415,11 @@ class Sensors:
                 f"toggles completed at "
                 f"{recovery_freq_hz} Hz"
             )
-            msg_dict["next_step"] = \
-                ("please reboot pi, restart flask server, and test bus using the diag "
-                 "command.  Reboot sequence may need to be repeated multiple times to "
-                 "resolve a locked i2c bus.")
+            msg_dict["next_step"] = (
+                "please reboot pi, restart flask server, and test bus using the diag "
+                "command.  Reboot sequence may need to be repeated multiple times to "
+                "resolve a locked i2c bus."
+            )
             return {"i2c_recovery": msg_dict}
         finally:
             GPIO.cleanup()  # clean up GPIO


### PR DESCRIPTION
There appear to be some python formatting errors in e76a1c6c4d75ce8fe7778438106ec76b0e34e854. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.