### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -11,7 +11,8 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('.'))
+
+sys.path.insert(0, os.path.abspath("."))
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -24,10 +25,10 @@ author = "Christopher Krolak"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.napoleon',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.napoleon",
 ]
 
 templates_path = ["_templates"]


### PR DESCRIPTION
There appear to be some python formatting errors in ae34e57cee959b17bf05d0e97137dd834acfd839. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.