### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/thermostatsupervisor/sht31_flask_server.py
+++ b/thermostatsupervisor/sht31_flask_server.py
@@ -791,11 +791,7 @@ def create_app():
     api = Api(app_)
 
     # Initialize rate limiter
-    Limiter(
-        get_remote_address,
-        app=app_,
-        default_limits=["200 per day", "60 per hour"]
-    )
+    Limiter(get_remote_address, app=app_, default_limits=["200 per day", "60 per hour"])
 
     # add API functions
     api.add_resource(Controller, "/")

--- a/thermostatsupervisor/supervisor_flask_server.py
+++ b/thermostatsupervisor/supervisor_flask_server.py
@@ -63,9 +63,7 @@ def create_app():
 app = create_app()
 # Initialize rate limiter
 limiter = Limiter(
-    get_remote_address,
-    app=app,
-    default_limits=["200 per day", "60 per hour"]
+    get_remote_address, app=app, default_limits=["200 per day", "60 per hour"]
 )
 csrf = CSRFProtect(app)  # enable CSRF protection
 ip_ban = flg.initialize_ipban(app)  # hacker blacklisting agent


### PR DESCRIPTION
There appear to be some python formatting errors in 0befa3fa3b664b3a95814bd9ad80e62737a42d25. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.