### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/thermostatsupervisor/nest.py
+++ b/thermostatsupervisor/nest.py
@@ -38,7 +38,7 @@ else:
 
 
 class ThermostatClass(tc.ThermostatCommon):
-    """ Nest Thermostat class.  """
+    """Nest Thermostat class."""
 
     def __init__(self, zone, verbose=True):
         """
@@ -288,7 +288,7 @@ class ThermostatClass(tc.ThermostatCommon):
 
 
 class ThermostatZone(tc.ThermostatCommonZone):
-    """ Nest Thermostat Zone class.  """
+    """Nest Thermostat Zone class."""
 
     def __init__(self, Thermostat_obj, verbose=True):
         """


### PR DESCRIPTION
There appear to be some python formatting errors in 9011c4c79763b6d6039d341c8339bb2fa547df22. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.