### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/tests/unit_test_common.py
+++ b/tests/unit_test_common.py
@@ -683,9 +683,7 @@ class RuntimeParameterTest(UnitTest):
         parser.add_argument("-f", type=argparse.FileType("r", encoding="UTF-8"))
         argv = ["-f" + input_file]  # space after sflag is appended onto str
         args = parser.parse_args(argv)
-        print(
-            f"args returned: {' '.join(f'{k}={v}' for k, v in vars(args).items())}"
-        )
+        print(f"args returned: {' '.join(f'{k}={v}' for k, v in vars(args).items())}")
         # assert(args.thermostat_type == "emulator")
 
     def is_valid_file(self, parser, arg):


### PR DESCRIPTION
There appear to be some python formatting errors in b711bdcb7a21de4702c665c273ea7e0b960d81c3. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.