### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/tests/test_sht31_flask_server.py
+++ b/tests/test_sht31_flask_server.py
@@ -260,7 +260,7 @@ class Sht31FlaskServerSensorUnit(utc.UnitTest):
             ([0x00, 0x00], 0x81),  # All zeros
             ([0xFF, 0xFF], 0xAC),  # All ones
             ([0xBE, 0xEF], 0x92),  # Random values
-            ([0xDE, 0xAD], 0x98),   # Random values
+            ([0xDE, 0xAD], 0x98),  # Random values
             ([0x12, 0x34], 0x37),  # Random values
         ]
 
@@ -270,25 +270,25 @@ class Sht31FlaskServerSensorUnit(utc.UnitTest):
                 calculated_crc,
                 expected_crc,
                 f"CRC mismatch for data {[hex(x) for x in data]}: "
-                f"expected {hex(expected_crc)}, got {hex(calculated_crc)}"
+                f"expected {hex(expected_crc)}, got {hex(calculated_crc)}",
             )
 
     def test_validate_crc(self):
         """Test CRC validation."""
         test_cases = [
             # (data, checksum, expected_result)
-            ([0x4A, 0xEA], 0xFC, True),   # actual data from SHT31
-            ([0x4A, 0x9B], 0x35, True),   # actual data from SHT31
-            ([0x00, 0x00], 0x81, True),   # Valid CRC
-            ([0xFF, 0xFF], 0xAC, True),   # Valid CRC
-            ([0xBE, 0xEF], 0x92, True),   # Valid CRC
-            ([0xDE, 0xAD], 0x98, True),   # Valid CRC
+            ([0x4A, 0xEA], 0xFC, True),  # actual data from SHT31
+            ([0x4A, 0x9B], 0x35, True),  # actual data from SHT31
+            ([0x00, 0x00], 0x81, True),  # Valid CRC
+            ([0xFF, 0xFF], 0xAC, True),  # Valid CRC
+            ([0xBE, 0xEF], 0x92, True),  # Valid CRC
+            ([0xDE, 0xAD], 0x98, True),  # Valid CRC
             ([0x00, 0x00], 0x00, False),  # Invalid CRC
             ([0xFF, 0xFF], 0xFF, False),  # Invalid CRC
             ([0x12, 0x34], 0x37, True),  # Valid CRC
             # Additional SHT31 typical test cases
-            ([0xBE, 0xFF], 0xd1, True),   # Valid CRC
-            ([0x65, 0x4C], 0xe3, True),   # Valid CRC
+            ([0xBE, 0xFF], 0xD1, True),  # Valid CRC
+            ([0x65, 0x4C], 0xE3, True),  # Valid CRC
         ]
 
         for data, checksum, expected in test_cases:
@@ -298,7 +298,7 @@ class Sht31FlaskServerSensorUnit(utc.UnitTest):
                 result,
                 expected,
                 f"CRC validation failed for data {[hex(x) for x in data]} "
-                f"with checksum {hex(checksum)}, actual={hex(actual)}"
+                f"with checksum {hex(checksum)}, actual={hex(actual)}",
             )
 
 

--- a/thermostatsupervisor/sht31_flask_server.py
+++ b/thermostatsupervisor/sht31_flask_server.py
@@ -130,7 +130,7 @@ class Sensors:
                 f"WARNING: CRC validation failed for temperature data: {data[0:2]}, "
                 f"Expected CRC: {data[2]}, "
                 f"Calculated CRC: {self.calculate_crc(data[0:2])}"
-                )
+            )
         elif self.verbose:
             print(f"temperature raw: {data[0:2]}, CRC: {data[2]}")
         if not self.validate_crc(data[3:5], data[5]):
@@ -138,7 +138,7 @@ class Sensors:
                 f"WARNING: CRC validation failed for humidity data: {data[3:5]}, "
                 f"Expected CRC: {data[5]}, "
                 f"Calculated CRC: {self.calculate_crc(data[3:5])}"
-                )
+            )
         elif self.verbose:
             print(f"humidity raw: {data[3:5]}, CRC: {data[5]}")
 
@@ -237,12 +237,12 @@ class Sensors:
                     if crc & 0x01:
                         crc = (crc >> 1) ^ poly
                     else:
-                        crc = (crc >> 1)
+                        crc = crc >> 1
                 else:
                     if crc & 0x80:
                         crc = (crc << 1) ^ poly  # polynomial = 0x31
                     else:
-                        crc = (crc << 1)
+                        crc = crc << 1
         crc &= 0xFF  # Ensure result is 8-bit
         crc ^= final_xor
         return crc
@@ -285,8 +285,10 @@ class Sensors:
             raise exc
 
         if len(response) != length:
-            raise ValueError(f"ERROR: i2c data read error, expected {length} "
-                             f"bytes, actual {len(response)}")
+            raise ValueError(
+                f"ERROR: i2c data read error, expected {length} "
+                f"bytes, actual {len(response)}"
+            )
 
         return response
 


### PR DESCRIPTION
There appear to be some python formatting errors in 8b6da6b94b1dc11e6fc2d37f94b8b1939df50aab. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.