### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/tests/test_sht31_flask_server.py
+++ b/tests/test_sht31_flask_server.py
@@ -67,14 +67,13 @@ class IntegrationTest(utc.UnitTest):
             if test_case in no_server_output_list:
                 self.assertTrue(
                     isinstance(return_data, type(None)),
-                    "return data is not NoneType, return type: "
-                    f"{type(return_data)}"
+                    "return data is not NoneType, return type: " f"{type(return_data)}",
                 )
             else:
                 self.assertTrue(
                     isinstance(return_data, dict),
                     "return data is not a dictionary, return type: "
-                    f"{type(return_data)}"
+                    f"{type(return_data)}",
                 )
 
             # validate key as proof of correct return page

--- a/thermostatsupervisor/flask_generic.py
+++ b/thermostatsupervisor/flask_generic.py
@@ -23,6 +23,7 @@ class CustomJSONEncoder(json.JSONEncoder):
     This encoder extends the default JSONEncoder to serialize datetime objects
     into ISO 8601 formatted strings.
     """
+
     def default(self, o):
         if isinstance(o, datetime.datetime):
             print(f"CustomJSONEncoder enabled: {o}")

--- a/thermostatsupervisor/sht31.py
+++ b/thermostatsupervisor/sht31.py
@@ -209,8 +209,9 @@ class ThermostatClass(tc.ThermostatCommon):
 
         # catch 404 web site response, no need to retry
         if "404 Not Found" in response.text:
-            fail_msg = \
+            fail_msg = (
                 f"FATAL ERROR 404: sht31 server does not support route {self.url}"
+            )
             util.log_msg(
                 fail_msg,
                 mode=util.BOTH_LOG,
@@ -220,8 +221,9 @@ class ThermostatClass(tc.ThermostatCommon):
 
         # catch 403 web site response, no need to retry
         if "403 Forbidden" in response.text:
-            fail_msg = \
+            fail_msg = (
                 f"FATAL ERROR 403: client is forbidden from accessing route {self.url}"
+            )
             util.log_msg(
                 fail_msg,
                 mode=util.BOTH_LOG,
@@ -237,8 +239,9 @@ class ThermostatClass(tc.ThermostatCommon):
                 return response.json()[parameter]
         except json.decoder.JSONDecodeError as ex:
             util.log_msg(traceback.format_exc(), mode=util.BOTH_LOG, func_name=1)
-            util.log_msg(f"raw response={response.text}", mode=util.BOTH_LOG,
-                         func_name=1)
+            util.log_msg(
+                f"raw response={response.text}", mode=util.BOTH_LOG, func_name=1
+            )
             if retry:
                 util.log_msg(
                     f"waiting {self.retry_delay} seconds and retrying SHT31 "

--- a/thermostatsupervisor/sht31_flask_server.py
+++ b/thermostatsupervisor/sht31_flask_server.py
@@ -925,7 +925,7 @@ def create_app():
         get_remote_address,
         app=app_,
         default_limits=["200 per day", "60 per hour"],
-        )
+    )
 
     # add API functions
     api.add_resource(Controller, "/")


### PR DESCRIPTION
There appear to be some python formatting errors in 34521a61079e013975c4ef5c657c8913785515e9. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.