### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/tests/test_email_notification.py
+++ b/tests/test_email_notification.py
@@ -37,9 +37,7 @@ class Test(utc.UnitTest):
                 _ = os.environ[env_key]
                 print(f"environment variable key {env_key} was found (PASS)")
             except KeyError:
-                fail_msg = (
-                    f"{env_key} environment variable missing from environment"
-                )
+                fail_msg = f"{env_key} environment variable missing from environment"
                 self.fail(fail_msg)
 
     def test_send_email_alerts(self):

--- a/tests/test_sht31_flask_server.py
+++ b/tests/test_sht31_flask_server.py
@@ -74,7 +74,7 @@ class IntegrationTest(utc.UnitTest):
             print(f"test_case={test_case}")
             Thermostat = sht31.ThermostatClass(
                 zone, path=sht31_config.flask_folder[test_case]
-                )
+            )
             print("printing thermostat meta data:")
             return_data = Thermostat.print_all_thermostat_metadata(zone)
 
@@ -98,7 +98,7 @@ class IntegrationTest(utc.UnitTest):
                 expected_key in return_data,
                 f"test_case '{test_case}': key '{expected_key}' "
                 f"was not found in return data: {return_data}",
-                )
+            )
 
     def test_sht31_flask_server(self):
         """


### PR DESCRIPTION
There appear to be some python formatting errors in f6e00c81eaaa8f8a27cfc9fa0c4acdd979dc9023. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.