### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/tests/unit_test_common.py
+++ b/tests/unit_test_common.py
@@ -390,8 +390,7 @@ class FunctionalIntegrationTest(IntegrationTest):
         self.assertIsInstance(
             metadata,
             dict,
-            f"metadata is type '{type(metadata)}', "
-            f"expected type '{dict}'",
+            f"metadata is type '{type(metadata)}', " f"expected type '{dict}'",
         )
 
     def test_get_meta_data(self):


### PR DESCRIPTION
There appear to be some python formatting errors in fa6cde7353bcbcbaac8f9725135279a74b34fd75. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.