### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/tests/unit_test_common.py
+++ b/tests/unit_test_common.py
@@ -125,7 +125,7 @@ class UnitTest(unittest.TestCase, metaclass=PatchMeta):
             )
 
         # update runtime parameters
-        if hasattr(self, 'Zone') and self.Zone is not None:
+        if hasattr(self, "Zone") and self.Zone is not None:
             self.Zone.update_runtime_parameters()
 
         # return the instances


### PR DESCRIPTION
There appear to be some python formatting errors in 0fae9917a29b6996e5d40f9bf6da2c7fc0af14aa. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.