### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -306,7 +306,7 @@ class MetricsTests(utc.UnitTest):
                         actual_val,
                         f"test case: {test_case}, expected_val="
                         f"{expected_val}, type {type(expected_val)}, actual_val="
-                        f"{actual_val}, type {type(actual_val)}"
+                        f"{actual_val}, type {type(actual_val)}",
                     )
 
         # test failing case

--- a/tests/unit_test_common.py
+++ b/tests/unit_test_common.py
@@ -694,7 +694,8 @@ class RuntimeParameterTest(UnitTest):
             else:
                 actual = self.uip.is_valid_file(filename)
                 self.assertIsInstance(
-                    actual, expected,
+                    actual,
+                    expected,
                     f"filename='{filename}', expected type={expected}, "
                     f"actual type={type(actual)}",
                 )


### PR DESCRIPTION
There appear to be some python formatting errors in 12c9bc8f2f90809bc76442bc563ebbcceb6de713. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.