### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/thermostatsupervisor/kumocloud.py
+++ b/thermostatsupervisor/kumocloud.py
@@ -440,9 +440,7 @@ class ThermostatZone(tc.ThermostatCommonZone):
         returns:
             (int): eco mode, 1=enabled, 0=disabled.
         """
-        return int(
-            self.get_parameter("energy_save", "reportedInitialSettings")
-        )
+        return int(self.get_parameter("energy_save", "reportedInitialSettings"))
 
     def is_off_mode(self) -> int:
         """


### PR DESCRIPTION
There appear to be some python formatting errors in 20686ab37fa27220ca7c57110ecc9b90b7054c7b. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.