### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/thermostatsupervisor/honeywell.py
+++ b/thermostatsupervisor/honeywell.py
@@ -66,7 +66,7 @@ class ThermostatClass(pyhtcc.PyHTCC, tc.ThermostatCommon):
 
     def close(self):
         """Explicitly close the session created in pyhtcc."""
-        if hasattr(self, 'session') and self.session is not None:
+        if hasattr(self, "session") and self.session is not None:
             self.session.close()
             self.session = None
 

--- a/thermostatsupervisor/honeywell.py
+++ b/thermostatsupervisor/honeywell.py
@@ -64,9 +64,19 @@ class ThermostatClass(pyhtcc.PyHTCC, tc.ThermostatCommon):
         self.zone_name = int(zone)
         self.device_id = self.get_target_zone_id(self.zone_name)
 
+    def close(self):
+        """Explicitly close the session created in pyhtcc."""
+        if hasattr(self, 'session') and self.session is not None:
+            self.session.close()
+            self.session = None
+
     def __del__(self):
-        """Clean-up session created in pyhtcc."""
-        self.session.close()
+        """Clean-up session created in pyhtcc (fallback)."""
+        try:
+            self.close()
+        except (AttributeError, TypeError):
+            # Handle cases where session doesn't exist or other cleanup issues
+            pass
 
     def _get_zone_device_ids(self) -> list:
         """

--- a/thermostatsupervisor/supervise.py
+++ b/thermostatsupervisor/supervise.py
@@ -84,7 +84,9 @@ def supervisor(thermostat_type, zone_str):
         mode=util.BOTH_LOG,
     )
 
-    # delete packages if necessary
+    # clean-up sessions and delete packages if necessary
+    if "Thermostat" in locals() and hasattr(Thermostat, 'close'):
+        Thermostat.close()
     if "Zone" in locals():
         del Zone
     if "Thermostat" in locals():

--- a/thermostatsupervisor/supervise.py
+++ b/thermostatsupervisor/supervise.py
@@ -85,7 +85,7 @@ def supervisor(thermostat_type, zone_str):
     )
 
     # clean-up sessions and delete packages if necessary
-    if "Thermostat" in locals() and hasattr(Thermostat, 'close'):
+    if "Thermostat" in locals() and hasattr(Thermostat, "close"):
         Thermostat.close()
     if "Zone" in locals():
         del Zone


### PR DESCRIPTION
There appear to be some python formatting errors in 6c29ab1325c466ae8d23d48ef188b3aa22a9a8d8. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.