### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/thermostatsupervisor/honeywell.py
+++ b/thermostatsupervisor/honeywell.py
@@ -66,7 +66,7 @@ class ThermostatClass(pyhtcc.PyHTCC, tc.ThermostatCommon):
 
     def close(self):
         """Explicitly close the session created in pyhtcc."""
-        if hasattr(self, 'session') and self.session is not None:
+        if hasattr(self, "session") and self.session is not None:
             self.session.close()
             self.session = None
 

--- a/thermostatsupervisor/supervise.py
+++ b/thermostatsupervisor/supervise.py
@@ -85,7 +85,7 @@ def supervisor(thermostat_type, zone_str):
     )
 
     # clean-up sessions and delete packages if necessary
-    if "Thermostat" in locals() and hasattr(Thermostat, 'close'):
+    if "Thermostat" in locals() and hasattr(Thermostat, "close"):
         Thermostat.close()
     if "Zone" in locals():
         del Zone


### PR DESCRIPTION
There appear to be some python formatting errors in ae2405ed6289e09120a9430c445b114f8519ef7b. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.