### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/thermostatsupervisor/honeywell.py
+++ b/thermostatsupervisor/honeywell.py
@@ -282,15 +282,15 @@ def get_zones_info_with_retries(func, thermostat_type, zone_name) -> list:
     """
     initial_trial_number = 1
     trial_number = initial_trial_number
-    
+
     # Use shorter retry parameters during unit testing to prevent test hanging
     if util.unit_test_mode:
         number_of_retries = 2  # Reduce from 5 to 2 retries
-        retry_delay_sec = 1    # Reduce from 60s to 1s initial delay
+        retry_delay_sec = 1  # Reduce from 60s to 1s initial delay
     else:
         number_of_retries = 5
         retry_delay_sec = 60
-    
+
     return_val = []
     while trial_number <= number_of_retries:
         time_now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
There appear to be some python formatting errors in c05dcd2c073bafebec04aeb4d8e42c197ec19c58. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.