### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/tests/test_emulator_integration.py
+++ b/tests/test_emulator_integration.py
@@ -56,70 +56,121 @@ class FunctionalIntegrationTest(IntegrationTest, utc.FunctionalIntegrationTest):
     def test_deviation_functionality(self):
         """Test emulator deviation functionality for improved testability."""
         self.print_test_name()
-        
-        # Create thermostat zone instance  
+
+        # Create thermostat zone instance
         Thermostat = self.mod.ThermostatClass(zone="0", verbose=False)
         Zone = self.mod.ThermostatZone(Thermostat, verbose=False)
-        
+
         try:
             # Test 1: Initial state - no deviation data
-            self.assertFalse(Zone.has_deviation_data(), "Should have no deviation data initially")
-            
+            self.assertFalse(
+                Zone.has_deviation_data(), "Should have no deviation data initially"
+            )
+
             # Get baseline values
             initial_temp = Zone.get_display_temp()
             initial_humidity = Zone.get_display_humidity()
             initial_heat_sp = Zone.get_heat_setpoint_raw()
             initial_cool_sp = Zone.get_cool_setpoint_raw()
-            
+
             # Test 2: Create deviation file
             Zone.create_deviation_file()
-            self.assertTrue(Zone.has_deviation_data(), "Should have deviation file after creation")
-            
+            self.assertTrue(
+                Zone.has_deviation_data(), "Should have deviation file after creation"
+            )
+
             # Test 3: Set specific deviation values
             test_temp = 85.5
             test_humidity = 60.0
             test_heat_sp = 68.0
             test_cool_sp = 76.0
-            
+
             Zone.set_deviation_value("display_temp", test_temp)
             Zone.set_deviation_value("display_humidity", test_humidity)
             Zone.set_deviation_value("heat_setpoint", test_heat_sp)
             Zone.set_deviation_value("cool_setpoint", test_cool_sp)
-            
+
             # Test 4: Verify deviation values are returned
-            self.assertTrue(Zone.has_deviation_data("display_temp"), "Should have temp deviation")
-            self.assertTrue(Zone.has_deviation_data("display_humidity"), "Should have humidity deviation")
-            self.assertTrue(Zone.has_deviation_data("heat_setpoint"), "Should have heat setpoint deviation")
-            self.assertTrue(Zone.has_deviation_data("cool_setpoint"), "Should have cool setpoint deviation")
-            
-            self.assertEqual(Zone.get_display_temp(), test_temp, "Should return deviated temperature")
-            self.assertEqual(Zone.get_display_humidity(), test_humidity, "Should return deviated humidity")
-            self.assertEqual(Zone.get_heat_setpoint_raw(), test_heat_sp, "Should return deviated heat setpoint")
-            self.assertEqual(Zone.get_cool_setpoint_raw(), test_cool_sp, "Should return deviated cool setpoint")
-            
+            self.assertTrue(
+                Zone.has_deviation_data("display_temp"), "Should have temp deviation"
+            )
+            self.assertTrue(
+                Zone.has_deviation_data("display_humidity"),
+                "Should have humidity deviation",
+            )
+            self.assertTrue(
+                Zone.has_deviation_data("heat_setpoint"),
+                "Should have heat setpoint deviation",
+            )
+            self.assertTrue(
+                Zone.has_deviation_data("cool_setpoint"),
+                "Should have cool setpoint deviation",
+            )
+
+            self.assertEqual(
+                Zone.get_display_temp(), test_temp, "Should return deviated temperature"
+            )
+            self.assertEqual(
+                Zone.get_display_humidity(),
+                test_humidity,
+                "Should return deviated humidity",
+            )
+            self.assertEqual(
+                Zone.get_heat_setpoint_raw(),
+                test_heat_sp,
+                "Should return deviated heat setpoint",
+            )
+            self.assertEqual(
+                Zone.get_cool_setpoint_raw(),
+                test_cool_sp,
+                "Should return deviated cool setpoint",
+            )
+
             # Test 5: Test individual value retrieval
-            self.assertEqual(Zone.get_deviation_value("display_temp"), test_temp, "Should retrieve specific deviation value")
-            self.assertIsNone(Zone.get_deviation_value("nonexistent_key"), "Should return None for missing key")
-            self.assertEqual(Zone.get_deviation_value("nonexistent_key", "default"), "default", "Should return default for missing key")
-            
+            self.assertEqual(
+                Zone.get_deviation_value("display_temp"),
+                test_temp,
+                "Should retrieve specific deviation value",
+            )
+            self.assertIsNone(
+                Zone.get_deviation_value("nonexistent_key"),
+                "Should return None for missing key",
+            )
+            self.assertEqual(
+                Zone.get_deviation_value("nonexistent_key", "default"),
+                "default",
+                "Should return default for missing key",
+            )
+
             # Test 6: Clear deviation data
             Zone.clear_deviation_data()
-            self.assertFalse(Zone.has_deviation_data(), "Should have no deviation data after clearing")
-            
+            self.assertFalse(
+                Zone.has_deviation_data(),
+                "Should have no deviation data after clearing",
+            )
+
             # Test 7: Verify normal behavior is restored
             # Note: We can't compare exact values due to random noise, but values should be in normal range
             current_temp = Zone.get_display_temp()
             current_humidity = Zone.get_display_humidity()
-            
+
             # Values should be within normal variation range from base values
             temp_diff = abs(current_temp - Zone.get_parameter("display_temp"))
-            humidity_diff = abs(current_humidity - Zone.get_parameter("display_humidity"))
-            
-            self.assertLessEqual(temp_diff, emulator_config.NORMAL_TEMP_VARIATION,
-                               "Temperature should be within normal variation after clearing deviation")
-            self.assertLessEqual(humidity_diff, emulator_config.NORMAL_HUMIDITY_VARIATION,
-                               "Humidity should be within normal variation after clearing deviation")
-            
+            humidity_diff = abs(
+                current_humidity - Zone.get_parameter("display_humidity")
+            )
+
+            self.assertLessEqual(
+                temp_diff,
+                emulator_config.NORMAL_TEMP_VARIATION,
+                "Temperature should be within normal variation after clearing deviation",
+            )
+            self.assertLessEqual(
+                humidity_diff,
+                emulator_config.NORMAL_HUMIDITY_VARIATION,
+                "Humidity should be within normal variation after clearing deviation",
+            )
+
         finally:
             # Cleanup: ensure deviation file is removed
             Zone.clear_deviation_data()

--- a/thermostatsupervisor/emulator.py
+++ b/thermostatsupervisor/emulator.py
@@ -149,10 +149,12 @@ class ThermostatZone(tc.ThermostatCommonZone):
         self.zone_name = Thermostat_obj.zone_name
         self.zone_info = Thermostat_obj.get_all_metadata(Thermostat_obj.zone_name)
         self.zone_name = self.get_zone_name()
-        
+
         # deviation file support for testing
-        self.deviation_file_path = util.get_full_file_path(f"emulator_deviation_zone_{self.device_id}.pkl")
-        
+        self.deviation_file_path = util.get_full_file_path(
+            f"emulator_deviation_zone_{self.device_id}.pkl"
+        )
+
         self.initialize_meta_data_dict()
 
     def initialize_meta_data_dict(self):
@@ -222,7 +224,7 @@ class ThermostatZone(tc.ThermostatCommonZone):
         deviation_temp = self.get_deviation_value("display_temp")
         if deviation_temp is not None:
             return float(deviation_temp)
-        
+
         # Normal behavior if no deviation data
         self.refresh_zone_info()
         return self.get_parameter("display_temp") + random.uniform(
@@ -242,12 +244,12 @@ class ThermostatZone(tc.ThermostatCommonZone):
         """
         if not self.get_is_humidity_supported():
             return None
-        
+
         # Check for deviation data first
         deviation_humidity = self.get_deviation_value("display_humidity")
         if deviation_humidity is not None:
             return float(deviation_humidity)
-        
+
         # Normal behavior if no deviation data
         return self.get_parameter("display_humidity") + random.uniform(
             -emulator_config.NORMAL_HUMIDITY_VARIATION,
@@ -464,7 +466,7 @@ class ThermostatZone(tc.ThermostatCommonZone):
         deviation_setpoint = self.get_deviation_value("heat_setpoint")
         if deviation_setpoint is not None:
             return float(deviation_setpoint)
-        
+
         # Normal behavior if no deviation data
         self.refresh_zone_info()
         return float(self.get_parameter("heat_setpoint"))
@@ -508,7 +510,7 @@ class ThermostatZone(tc.ThermostatCommonZone):
         deviation_setpoint = self.get_deviation_value("cool_setpoint")
         if deviation_setpoint is not None:
             return float(deviation_setpoint)
-        
+
         # Normal behavior if no deviation data
         self.refresh_zone_info()
         return float(self.get_parameter("cool_setpoint"))
@@ -585,26 +587,26 @@ class ThermostatZone(tc.ThermostatCommonZone):
     def create_deviation_file(self) -> None:
         """
         Create an empty deviation file for this thermostat zone.
-        
+
         inputs:
             None
         returns:
             None
         """
         deviation_data = {}
-        with open(self.deviation_file_path, 'wb') as handle:
+        with open(self.deviation_file_path, "wb") as handle:
             pickle.dump(deviation_data, handle)
         if self.verbose:
             util.log_msg(
                 f"Created deviation file: {self.deviation_file_path}",
                 mode=util.BOTH_LOG,
-                func_name=1
+                func_name=1,
             )
 
     def set_deviation_value(self, key: str, value) -> None:
         """
         Set a deviation value for a specific parameter.
-        
+
         inputs:
             key(str): parameter name (e.g., 'display_temp', 'display_humidity')
             value: deviation value to set
@@ -615,29 +617,29 @@ class ThermostatZone(tc.ThermostatCommonZone):
         deviation_data = {}
         if os.path.exists(self.deviation_file_path):
             try:
-                with open(self.deviation_file_path, 'rb') as handle:
+                with open(self.deviation_file_path, "rb") as handle:
                     deviation_data = pickle.load(handle)
             except (pickle.PickleError, EOFError):
                 deviation_data = {}
-        
+
         # Update the value
         deviation_data[key] = value
-        
+
         # Write back to file
-        with open(self.deviation_file_path, 'wb') as handle:
+        with open(self.deviation_file_path, "wb") as handle:
             pickle.dump(deviation_data, handle)
-        
+
         if self.verbose:
             util.log_msg(
                 f"Set deviation value {key}={value} in {self.deviation_file_path}",
                 mode=util.BOTH_LOG,
-                func_name=1
+                func_name=1,
             )
 
     def get_deviation_value(self, key: str, default_val=None):
         """
         Get a deviation value for a specific parameter.
-        
+
         inputs:
             key(str): parameter name
             default_val: default value if key not found or file doesn't exist
@@ -646,9 +648,9 @@ class ThermostatZone(tc.ThermostatCommonZone):
         """
         if not os.path.exists(self.deviation_file_path):
             return default_val
-        
+
         try:
-            with open(self.deviation_file_path, 'rb') as handle:
+            with open(self.deviation_file_path, "rb") as handle:
                 deviation_data = pickle.load(handle)
                 return deviation_data.get(key, default_val)
         except (pickle.PickleError, EOFError):
@@ -657,7 +659,7 @@ class ThermostatZone(tc.ThermostatCommonZone):
     def has_deviation_data(self, key: str = None) -> bool:
         """
         Check if deviation data exists.
-        
+
         inputs:
             key(str): if provided, check for specific key, otherwise check if file exists
         returns:
@@ -665,12 +667,12 @@ class ThermostatZone(tc.ThermostatCommonZone):
         """
         if not os.path.exists(self.deviation_file_path):
             return False
-        
+
         if key is None:
             return True
-        
+
         try:
-            with open(self.deviation_file_path, 'rb') as handle:
+            with open(self.deviation_file_path, "rb") as handle:
                 deviation_data = pickle.load(handle)
                 return key in deviation_data
         except (pickle.PickleError, EOFError):
@@ -679,7 +681,7 @@ class ThermostatZone(tc.ThermostatCommonZone):
     def clear_deviation_data(self) -> None:
         """
         Clear all deviation data by removing the deviation file.
-        
+
         inputs:
             None
         returns:
@@ -691,7 +693,7 @@ class ThermostatZone(tc.ThermostatCommonZone):
                 util.log_msg(
                     f"Cleared deviation file: {self.deviation_file_path}",
                     mode=util.BOTH_LOG,
-                    func_name=1
+                    func_name=1,
                 )
 
     def refresh_zone_info(self, force_refresh=False):


### PR DESCRIPTION
There appear to be some python formatting errors in 969f9320505e7436b74390d9d2082fc6afa64bcd. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.