### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/thermostatsupervisor/honeywell.py
+++ b/thermostatsupervisor/honeywell.py
@@ -280,7 +280,7 @@ def get_zones_info_with_retries(func, thermostat_type, zone_name) -> list:
     returns:
         list of zone info.
     """
-   
+
     # Define Honeywell-specific exception types
     honeywell_exceptions = (
         pyhtcc.requests.exceptions.ConnectionError,


### PR DESCRIPTION
There appear to be some python formatting errors in e714e6ff765b9329641a34307c37c60b5b9f3675. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.