### PR TITLE
resolves #1322 added autostart file copy and updated repo to match lo…

### DIFF
--- a/sht31_autostart_desktop
+++ b/sht31_autostart_desktop
@@ -5,7 +5,7 @@
 [Desktop Entry]
 Encoding=UTF-8
 Name=SHT31 server autostart
-Comment=Start a terminal and launch sht31 server
-Exec=/usr/bin/lxterm -hold -e 'cd /home/pi/github/ThermostatSupervisor && python -m src.sht31_flask_server'
+Comment=Start a terminal, start DNS service, pull latest dev branch, and launch sht31 server
+Exec=/usr/bin/lxterm -hold -e 'cd /home/pi/github/ThermostatSupervisor && sudo /usr/local/bin/noip2 && sudo noip2 -S && git checkout develop && git pull && cp sht31_autostart_desktop ~/.config/autostart/lxterm-autostart.desktop && pip install -r requirements.txt -r requirements_sht31.txt && python -m src.sht31_flask_server'
 Terminal=true
 X-KeepTerminal=true

--- a/sht31_autostart_desktop
+++ b/sht31_autostart_desktop
@@ -6,6 +6,6 @@
 Encoding=UTF-8
 Name=SHT31 server autostart
 Comment=Start a terminal, start DNS service, pull latest dev branch, and launch sht31 server
-Exec=/usr/bin/lxterm -hold -e 'cd /home/pi/github/ThermostatSupervisor && sudo /usr/local/bin/noip2 && sudo noip2 -S && git checkout develop && git pull && cp sht31_autostart_desktop ~/.config/autostart/lxterm-autostart.desktop && pip install -r requirements.txt -r requirements_sht31.txt && python -m src.sht31_flask_server'
+Exec=/usr/bin/lxterm -hold -e 'cd /home/pi/github/ThermostatSupervisor && sudo /usr/local/bin/noip2 && sudo /usr/local/bin/noip2 -S && git checkout develop && git pull && mkdir -p /home/pi/.config/autostart && cp sht31_autostart_desktop /home/pi/.config/autostart/lxterm-autostart.desktop && pip install -r requirements.txt -r requirements_sht31.txt && python -m src.sht31_flask_server'
 Terminal=true
 X-KeepTerminal=true


### PR DESCRIPTION
…cal install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the SHT31 desktop autostart to: start the DNS service, switch to the development branch and pull latest code, ensure autostart is in place, install required Python dependencies, and then launch the SHT31 server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->