### PR TITLE
resolves #1432 updating auth headers and api version

### DIFF
--- a/src/kumocloud.py
+++ b/src/kumocloud.py
@@ -120,15 +120,26 @@ class ThermostatClass(tc.ThermostatCommon):
         """
         self._authentication_attempted = True
 
+        V3_APP_VERSION = "3.2.4"
+        V3_CLOUD_TIMEOUT = (10, 30)  # (connect, read)
         login_url = f"{self.base_url}/v3/login"
         login_data = {
             "username": self.kc_uname,
             "password": self.kc_pwd,
-            "appVersion": "3.0.9",
+            "appVersion": V3_APP_VERSION,
+        }
+        login_headers = {
+            "Accept": "application/json",
+            "Accept-Encoding": "gzip, deflate, br",
+            "x-app-version": V3_APP_VERSION,
+            "Content-Type": "application/json",
         }
 
         try:
-            response = self.session.post(login_url, json=login_data, timeout=30)
+            response = self.session.post(login_url,
+                                         headers=login_headers,
+                                         json=login_data,
+                                         timeout=V3_CLOUD_TIMEOUT)
             response.raise_for_status()
 
             auth_response = response.json()

--- a/src/kumocloud.py
+++ b/src/kumocloud.py
@@ -130,16 +130,18 @@ class ThermostatClass(tc.ThermostatCommon):
         }
         login_headers = {
             "Accept": "application/json",
-            "Accept-Encoding": "gzip, deflate, br",
+            "Accept-Encoding": "gzip, deflate",
             "x-app-version": V3_APP_VERSION,
             "Content-Type": "application/json",
         }
 
         try:
-            response = self.session.post(login_url,
-                                         headers=login_headers,
-                                         json=login_data,
-                                         timeout=V3_CLOUD_TIMEOUT)
+            response = self.session.post(
+                login_url,
+                headers=login_headers,
+                json=login_data,
+                timeout=V3_CLOUD_TIMEOUT,
+            )
             response.raise_for_status()
 
             auth_response = response.json()

--- a/tests/test_kumocloud_unit.py
+++ b/tests/test_kumocloud_unit.py
@@ -370,6 +370,15 @@ class AuthenticationUnitTest(utc.UnitTest):
         ):
             thermostat = kumocloud.ThermostatClass(zone=0, verbose=False)
 
+            # Verify session.post was called with expected headers and timeout
+            mock_session.post.assert_called_once()
+            call_kwargs = mock_session.post.call_args.kwargs
+            self.assertEqual(
+                call_kwargs["headers"].get("Accept-Encoding"), "gzip, deflate"
+            )
+            self.assertIsInstance(call_kwargs["timeout"], tuple)
+            self.assertEqual(len(call_kwargs["timeout"]), 2)
+
             # Verify authentication succeeded
             self.assertTrue(getattr(thermostat, "_authenticated"))  # type: ignore
             self.assertEqual(thermostat.auth_token, "test_access_token_123")


### PR DESCRIPTION
root cause of auth error was that I updated username from cjkrolak2 to cjkrolak (user error).  During investation found out of date authentication post parameters so updated those to match the source repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KumoCloud sign-in reliability with updated authentication settings, explicit request headers, and separate connection and response timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->